### PR TITLE
chore(ci/docs/tests): add dev-proxy README, generator test, and run full tests in CI

### DIFF
--- a/packages/opencode-warcraft-notifications-plugin/src/index.test.ts
+++ b/packages/opencode-warcraft-notifications-plugin/src/index.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
+
 import { OpencodeWarcraftNotificationsPlugin } from './index';
 
 describe('OpencodeWarcraftNotificationsPlugin', () => {


### PR DESCRIPTION
## Summary

- Add README for  executor to document usage and options
- Add descriptions and example to 
- Document template variables and test guidance in 
- Add minimal generator unit test at 
- Add a full-test step (bun test v1.3.3 (274e01c7)
dev-proxy: workspaceRoot= /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins
dev-proxy: project opencode-warcraft-notifications-plugin not found in workspace via devkit; falling back to plugin resolution
Started build target for opencode-warcraft-notifications-plugin via @nx/devkit.runExecutor
Running dev proxy runtime: bunx tsx /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins/tools/dev/opencode-dev.ts opencode-warcraft-notifications-plugin

Interrupted. Stopping build watchers and exiting...
dev-proxy: workspaceRoot= /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins
dev-proxy: project opencode-warcraft-notifications-plugin not found in workspace via devkit; falling back to plugin resolution
Falling back to CLI watcher for opencode-warcraft-notifications-plugin
Running dev proxy runtime: bunx tsx /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins/tools/dev/opencode-dev.ts opencode-warcraft-notifications-plugin

Interrupted. Stopping build watchers and exiting...
dev-proxy: workspaceRoot= /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins
dev-proxy: project pA not found in workspace via devkit; falling back to plugin resolution
Started build target for pA via @nx/devkit.runExecutor
dev-proxy: project pB not found in workspace via devkit; falling back to plugin resolution
Started build target for pB via @nx/devkit.runExecutor
Running dev proxy runtime: bunx tsx /Users/thomas.roche/Projects/github/pantheon-org/opencode-plugins/tools/dev/opencode-dev.ts pA pB

Interrupted. Stopping build watchers and exiting...) to the PR validation workflow
- Link executor README from 

## Files changed
- 
- 
- 
- 
- 
- 

## Notes
- Executor tests were hardened to stub  and  so CI won't start long-running processes.
- Full test suite was run locally and passed before creating this PR.
