### PR TITLE
refactor(tools): Convert executors and generators to ESM and integrate with Nx

### DIFF
--- a/tools/executors/dev-proxy/tsconfig.json
+++ b/tools/executors/dev-proxy/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/tools/executors/typecheck/tsconfig.json
+++ b/tools/executors/typecheck/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/tools/generators/plugin/tsconfig.json
+++ b/tools/generators/plugin/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "typeRoots": ["../../../types", "../../../node_modules"]
+    "typeRoots": ["../../../types", "../../../node_modules/@types"],
+    "types": ["node"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

This PR completes the ESM migration for the tools directory by converting all Nx executors and generators to pure ESM and properly registering them as Nx projects.

### Changes

**1. ESM Conversion**
- ✅ Converted `dev-proxy` executor from CommonJS to ESM
  - Replaced all `require()` with `import` statements
  - Fixed path resolution using `fileURLToPath` and `import.meta.url`
  - Fixed Nx devkit imports (`readProjectsConfigurationFromProjectGraph`, `createProjectGraphAsync`)
  
- ✅ Converted `typecheck` executor from CommonJS to ESM
  - Replaced all `require()` with `import` statements
  - Fixed dynamic imports to use `await import()`

- ✅ Refactored plugin generator structure
  - Moved implementation files to `src/` subdirectory
  - Split large modules into smaller focused functions
  - Fixed all linting and import order errors

**2. Nx Project Registration**
- ✅ Added `project.json` for all 3 tools (dev-proxy, typecheck, generator-plugin)
- ✅ Each includes `lint`, `type-check`, and `test` targets
- ✅ Configured to lint only `.ts` source files (excludes test files)
- ✅ Integrated with Nx caching and `nx affected` commands

**3. TypeScript Configuration**
- ✅ Created missing `tsconfig.json` for typecheck executor
- ✅ Fixed typeRoots and node types resolution for generator-plugin
- ✅ Excluded test files from type-checking where appropriate

### Results

```bash
# Workspace now has 6 Nx projects (up from 3)
$ nx show projects
✅ opencode-warcraft-notifications-plugin
✅ executor-dev-proxy
✅ executor-typecheck
✅ generator-plugin
✅ opencode-font
✅ docs-builder

# All tools pass lint (0 errors)
$ nx run-many --target=lint --projects="executor-*,generator-*"
✅ Successfully ran target lint for 3 projects

# All tools pass type-check (0 errors)
$ nx run-many --target=type-check --projects="executor-*,generator-*"
✅ Successfully ran target type-check for 3 projects

# ESM compliance verified
$ bun run check:esm
✅ No require() violations found in ESM packages!
```

### File Statistics
- 44 files changed: +1,748 insertions, -124 deletions
- Tools now follow pure ESM standards
- Fully integrated with Nx workflow (`nx run`, `nx affected`, caching)

### Testing
- ✅ All executors run successfully
- ✅ Generator creates plugins correctly
- ✅ Lint passes with 0 errors
- ✅ Type-check passes with 0 errors
- ✅ ESM compliance check passes

## Related Work
This builds on the ESM migration work from previous PRs and completes the tools directory migration.